### PR TITLE
✨ Single-field index exemptions and TTL on soft-deleted documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
 # 🔖 Changelog
 
 ## Unreleased
+
+Features:
+
+- Implement the `single_field_index_exemptions` to easily remove indexes from single fields in a collection.
+- Implement the `expire_soft_deleted_documents` to define the TTL policy on the related "soft-deleted documents" collection.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,61 @@
 # Terraform module for Firestore collections
+
+This module is a helper to define Firestore collections using Terraform. While a Firestore collection doesn't need to be created (it exists as soon as a document is added to it), some aspects of it can be managed by Terraform, like indexes and TTLs.
+
+This module provides features that integrate with [Causa](https://github.com/causa-io) concepts, like the soft-deleted document collection.
+
+## ➕ Requirements
+
+This module depends on the [google Terraform provider](https://registry.terraform.io/providers/hashicorp/google/latest).
+
+## 🎉 Installation
+
+Copy the following in your Terraform configuration, and run `terraform init`:
+
+```terraform
+module "my_collection" {
+  source  = "causa-io/firestore-collection/google"
+  version = "<insert the most recent version number here>"
+
+  # The name of the Firestore collection.
+  name = "myCollection"
+}
+```
+
+## ✨ Features
+
+### Single field index exemptions
+
+It is [recommended](https://firebase.google.com/docs/firestore/query-data/index-overview#indexing_best_practices) that fields containing sequential values should not be indexed. This is usually the case for "lifecycle" timestamp fields, such as `createdAt` and `updatedAt`. If you don't need to query on those fields, you can disable indexing on them by adding them to the `single_field_index_exemptions` list:
+
+```terraform
+module "my_collection" {
+  source  = "causa-io/firestore-collection/google"
+  version = "<insert the most recent version number here>"
+
+  name = "myCollection"
+
+  # These fields will not be indexed.
+  single_field_index_exemptions = ["createdAt", "updatedAt", "deletedAt"]
+}
+```
+
+### Soft-deleted documents TTL
+
+The Causa runtime (for example the [TypeScript Google runtime](https://github.com/causa-io/runtime-typescript-google) with the `FirestoreStateTransaction`) can move documents with a non-null `deletedAt` field to a separate "soft-deleted" collection (suffixed with `$deleted`), such that the documents can no longer be queried by clients. Those documents are kept in the "soft-deleted" collection also to account for unordered event processing.
+
+The Causa runtime sets an additional field in the soft-deleted documents, `_expirationDate`, which can be used by the TTL policy. This Terraform module automatically sets the TTL policy, and disables indexing on the `_expirationDate` field.
+
+If you don't need this feature on a collection (i.e. it does not have a "soft-deleted" counterpart), the TTL (and index exemption) can be disabled using the `expire_soft_deleted_documents` variable:
+
+```terraform
+module "my_collection" {
+  source  = "causa-io/firestore-collection/google"
+  version = "<insert the most recent version number here>"
+
+  name = "myCollection"
+  # When explicitly set to `false`, the module will not set the TTL on the `myCollection$deleted._expirationDate` field.
+  # It will not disable indexing on it either.
+  expire_soft_deleted_documents = false
+}
+```

--- a/main.tf
+++ b/main.tf
@@ -1,1 +1,9 @@
+# This defines fields with an empty `index_config` block which disables indexing on them.
+resource "google_firestore_field" "index_exempted" {
+  for_each = var.single_field_index_exemptions
 
+  collection = var.name
+  field      = each.key
+
+  index_config {}
+}

--- a/main.tf
+++ b/main.tf
@@ -7,3 +7,15 @@ resource "google_firestore_field" "index_exempted" {
 
   index_config {}
 }
+
+# The collection suffixed with `$deleted` is used to store soft-deleted documents, which should be deleted when
+# `_expirationDate` is reached.
+resource "google_firestore_field" "deleted_ttl" {
+  count = var.expire_soft_deleted_documents ? 1 : 0
+
+  collection = "${var.name}$deleted"
+  field      = "_expirationDate"
+
+  index_config {}
+  ttl_config {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -8,3 +8,9 @@ variable "single_field_index_exemptions" {
   description = "A set of field names that should not be indexed."
   default     = []
 }
+
+variable "expire_soft_deleted_documents" {
+  type        = bool
+  description = "Whether to set a TTL on the soft-deleted collection to automatically garbage collect documents in it. Defaults to `true`."
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,1 +1,10 @@
+variable "name" {
+  type        = string
+  description = "The name of the Firestore collection."
+}
 
+variable "single_field_index_exemptions" {
+  type        = set(string)
+  description = "A set of field names that should not be indexed."
+  default     = []
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,1 +1,8 @@
-
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.75.0, < 5.0"
+    }
+  }
+}


### PR DESCRIPTION
This PR implements the first version of the module, allowing single-field index exemptions and setting TTL on soft-deleted documents.

### Commits

- ➕ Depend on the google Terraform provider
- ✨ Define single_field_index_exemptions logic
- ✨ Implement the expire_soft_deleted_documents logic
- 📝 Update changelog
- 📝 Document the module