### PR TITLE
✨ `gcp_project_id` variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Expose the `gcp_project_id` variable.
+
 ## v0.1.0 (2023-07-26)
 
 Features:

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,7 @@
 resource "google_firestore_field" "index_exempted" {
   for_each = var.single_field_index_exemptions
 
+  project    = var.gcp_project_id
   collection = var.name
   field      = each.key
 
@@ -13,6 +14,7 @@ resource "google_firestore_field" "index_exempted" {
 resource "google_firestore_field" "deleted_ttl" {
   count = var.expire_soft_deleted_documents ? 1 : 0
 
+  project    = var.gcp_project_id
   collection = "${var.name}$deleted"
   field      = "_expirationDate"
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "gcp_project_id" {
+  type        = string
+  description = "The GCP project ID in which the collections are configured."
+  default     = null
+}
+
 variable "name" {
   type        = string
   description = "The name of the Firestore collection."


### PR DESCRIPTION
The title says it all. This allows overriding the default GCP project.

### Commits

- ✨ Expose the GCP project ID as a variable
- 📝 Update changelog