### PR TITLE
🔖 Prepare v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.2.1 (2024-02-21)
+
 Chores:
 
 - Upgrade compatible `google` provider versions to support `5.*.*`.


### PR DESCRIPTION
Chores:

- Upgrade compatible `google` provider versions to support `5.*.*`.

### Commits

- 📝 Update changelog