### PR TITLE
✨ `database` variable to support custom databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Expose the `database` variable. It defaults to `(default)`.
+
 ## v0.2.1 (2024-02-21)
 
 Chores:

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,7 @@ resource "google_firestore_field" "index_exempted" {
   for_each = var.single_field_index_exemptions
 
   project    = var.gcp_project_id
+  database   = var.database
   collection = var.name
   field      = each.key
 
@@ -15,6 +16,7 @@ resource "google_firestore_field" "deleted_ttl" {
   count = var.expire_soft_deleted_documents ? 1 : 0
 
   project    = var.gcp_project_id
+  database   = var.database
   collection = "${var.name}$deleted"
   field      = "_expirationDate"
 

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "gcp_project_id" {
   default     = null
 }
 
+variable "database" {
+  type        = string
+  description = "The name of the Firestore database. Defaults to the `(default)` database."
+  default     = "(default)"
+}
+
 variable "name" {
   type        = string
   description = "The name of the Firestore collection."


### PR DESCRIPTION
The title says it all. `database` is optional and defaults to `(default)` (which was the only value allowed before Firestore introduced multiple database support).

### Commits

- **✨ Support the database variable**
- **📝 Update changelog**