### PR TITLE
🔖 Prepare v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.3.2 (2025-10-16)
+
 Chores:
 
 - Bump google provider supported versions.


### PR DESCRIPTION
Chores:

- Bump google provider supported versions.