### PR TITLE
✨ Expose timeout for field operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Support configuring a timeout for field create and update operations.
+
 ## v0.3.2 (2025-10-16)
 
 Chores:

--- a/README.md
+++ b/README.md
@@ -59,3 +59,7 @@ module "my_collection" {
   expire_soft_deleted_documents = false
 }
 ```
+
+### Field timeout
+
+Firestore field operations can sometimes take a long time to apply, which may cause Terraform to timeout. The timeout for create and update operations on field resources can be configured using the `timeout` Terraform variable. It accepts a string duration, e.g. `"60m"`.

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,15 @@ resource "google_firestore_field" "index_exempted" {
   field      = each.key
 
   index_config {}
+
+  dynamic "timeouts" {
+    for_each = var.timeout != null ? [1] : []
+
+    content {
+      create = var.timeout
+      update = var.timeout
+    }
+  }
 }
 
 # The collection suffixed with `$deleted` is used to store soft-deleted documents, which should be deleted when
@@ -22,4 +31,13 @@ resource "google_firestore_field" "deleted_ttl" {
 
   index_config {}
   ttl_config {}
+
+  dynamic "timeouts" {
+    for_each = var.timeout != null ? [1] : []
+
+    content {
+      create = var.timeout
+      update = var.timeout
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -26,3 +26,9 @@ variable "expire_soft_deleted_documents" {
   description = "Whether to set a TTL on the soft-deleted collection to automatically garbage collect documents in it. Defaults to `true`."
   default     = true
 }
+
+variable "timeout" {
+  type        = string
+  description = "The timeout for create and update operations on the Firestore fields. This can be increased for fields that take a long time to apply."
+  default     = null
+}


### PR DESCRIPTION
- Add a `timeout` variable to configure create and update timeouts on Firestore field resources.
- Apply the timeout to both `index_exempted` and `deleted_ttl` field resources using a dynamic `timeouts` block.